### PR TITLE
Make SSH keys dropdown item a link to the auth docs

### DIFF
--- a/app/console/ui/html/console.html
+++ b/app/console/ui/html/console.html
@@ -217,7 +217,7 @@
               </div>
               {{if eq .BillingInfo.Plan "Basic"}}<div onclick="$('#upgrade-modal').modal('show')" class="item">Upgrade</div>{{end}}
               <div onclick="$('#billing-modal').modal('show')" class="item">Billing</div>
-              <div class="item">SSH Keys</div>
+              <a class="item" href="https://www.cmd.io/cli/#authentication">SSH Keys</a>
               <div class="divider"></div>
               <a class="item" href="/_auth/logout">Logout</a>
             </div>


### PR DESCRIPTION
This is temporary until cmd.io supports hosting SSH keys rather than solely GitHub user auth