### PR TITLE
app/runapi: pass the body as stdin

### DIFF
--- a/app/runapi/session.go
+++ b/app/runapi/session.go
@@ -21,7 +21,6 @@ const (
 type httpSession struct {
 	req         *http.Request
 	wc          io.WriteCloser
-	stdin       io.ReadCloser
 	token       string
 	isWebSocket bool
 	ctx         context.Context
@@ -32,7 +31,7 @@ func (sess *httpSession) Write(p []byte) (n int, err error) {
 	return sess.wc.Write(p)
 }
 func (sess *httpSession) Read(data []byte) (int, error) {
-	return sess.stdin.Read(data)
+	return sess.req.Body.Read(data)
 }
 func (sess *httpSession) PublicKey() ssh.PublicKey {
 	return nil
@@ -97,7 +96,7 @@ func (sess *httpSession) Pty() (ssh.Pty, <-chan ssh.Window, bool) {
 }
 
 func (sess *httpSession) Close() error {
-	sess.stdin.Close()
+	sess.req.Body.Close()
 	return sess.wc.Close()
 }
 func (sess *httpSession) CloseWrite() error {

--- a/app/runapi/web.go
+++ b/app/runapi/web.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -97,7 +96,6 @@ func (c *Component) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	session := &httpSession{
 		req:         r,
 		wc:          wc,
-		stdin:       ioutil.NopCloser(strings.NewReader("")),
 		token:       token.Key,
 		isWebSocket: isWebSocket,
 		ctx:         ctx,


### PR DESCRIPTION
The API reference already claims works. This makes it work.

An example of how to use it is as follows:

```sh
$ cat tac
#!cmd.io alpine
#!/bin/sh
exec tac

$ ssh -t -p 2223 user@localhost :create tac < tac
$ echo "foo\nbar" | curl --data-binary @- -u "..." http://localhost:8080/run/user/tac
bar
foo
$
```